### PR TITLE
0.3.2 New object creation

### DIFF
--- a/Editor/SerializeReferenceDropdownPropertyDrawer.cs
+++ b/Editor/SerializeReferenceDropdownPropertyDrawer.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.Serialization;
 using UnityEditor;
 using UnityEditor.IMGUI.Controls;
 using UnityEditor.UIElements;
@@ -147,7 +148,7 @@ namespace SerializeReferenceDropdown.Editor
         private void WriteNewInstanceByIndexType(int typeIndex, SerializedProperty property)
         {
             var newType = assignableTypes[typeIndex];
-            var newObject = newType != null ? Activator.CreateInstance(newType) : null;
+            var newObject = newType != null ? FormatterServices.GetUninitializedObject(newType) : null;
             ApplyValueToProperty(newObject, property);
         }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.alexeytaranov.serializereferencedropdown",
-  "version": "0.2.0",
+  "version": "0.3.2",
   "displayName": "SerializeReferenceDropdown",
   "description": "Editor dropdown for SerializeReference Attribute",
   "unity": "2019.3",


### PR DESCRIPTION
Activator.CreateInstance() - can't create objects without default constructor