### PR TITLE
Change Instantiation of object

### DIFF
--- a/Editor/SerializeReferenceDropdownPropertyDrawer.cs
+++ b/Editor/SerializeReferenceDropdownPropertyDrawer.cs
@@ -179,7 +179,17 @@ namespace SerializeReferenceDropdown.Editor
         private void WriteNewInstanceByIndexType(int typeIndex, SerializedProperty property)
         {
             var newType = assignableTypes[typeIndex];
-            var newObject = newType != null ? FormatterServices.GetUninitializedObject(newType) : null;
+
+            object newObject;
+            if (newType.GetConstructor(Type.EmptyTypes) != null)
+            {
+                newObject = newType != null ? Activator.CreateInstance(newType) : null;
+            }
+            else
+            {
+                newObject = newType != null ? FormatterServices.GetUninitializedObject(newType) : null;
+            }
+
             ApplyValueToProperty(newObject, property);
         }
 


### PR DESCRIPTION
Added option to use Activator.CreateInstance in cases where it is supported, so that the default Values are set. 
Only fallback to FromatterServices when there is no Empty Constructor.