### PR TITLE
Remove direct white colour assignment. 

### DIFF
--- a/Editor/Dropdown/SerializeReferencePropertyDrawer_UIToolkit.cs
+++ b/Editor/Dropdown/SerializeReferencePropertyDrawer_UIToolkit.cs
@@ -108,7 +108,6 @@ namespace SerializeReferenceDropdown.Editor.Dropdown
 
                 var activeSearchTool = SerializeReferenceToolsUserPreferences.GetOrLoadSettings().EnableSearchTool;
                 showSearchToolButton.SetDisplayElement(selectedType != null && activeSearchTool);
-                selectTypeButton.style.color = new StyleColor(Color.white);
                 fixCrossRefButton.SetDisplayElement(false);
                 
                 modifyDirectType.SetDisplayElement(selectedType != null);


### PR DESCRIPTION
Assigning white colour made it quite unusable with light editor theme.
Checked light and dark themes and both looked OK now. 

Tried checking IMGUI code as well, but didn't find direct colour assignment there.