### PR TITLE
Fix AssemblyFlags ambiguity on Unity 6000.5

### DIFF
--- a/Editor/Utils/TypeUtils.cs
+++ b/Editor/Utils/TypeUtils.cs
@@ -361,7 +361,7 @@ namespace SerializeReferenceDropdown.Editor.Utils
             if (systemObjectTypes == null)
             {
                 var assemblies = CompilationPipeline.GetAssemblies();
-                var playerAssemblies = assemblies.Where(t => t.flags.HasFlag(AssemblyFlags.EditorAssembly) == false)
+                var playerAssemblies = assemblies.Where(t => t.flags.HasFlag(UnityEditor.Compilation.AssemblyFlags.EditorAssembly) == false)
                     .Select(t => t.name).ToArray();
                 var baseType = typeof(object);
                 var typesCollection = TypeCache.GetTypesDerivedFrom(baseType);


### PR DESCRIPTION
## Summary
- Qualify `AssemblyFlags.EditorAssembly` with `UnityEditor.Compilation` to avoid ambiguity with `System.Reflection.AssemblyFlags`.

## Why
Unity 6000.5 reports `AssemblyFlags` as ambiguous in `TypeUtils.cs` because both `UnityEditor.Compilation` and `System.Reflection` are imported.

## Validation
- Verified the change is a one-line namespace qualification.
- This resolves the `CS0104` ambiguity while preserving existing behavior.